### PR TITLE
Handle exif information in JPEGs to display images in correct orientation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ set(wxWidgets_USE_STATIC ON)
 find_package(wxWidgets COMPONENTS core base adv REQUIRED)
 include(${wxWidgets_USE_FILE})
 
+find_library(EXIF_LIB easyexif REQUIRED)
+
 set(APP_SRC
     main.cpp
     saverframe.cpp
@@ -49,6 +51,7 @@ set(CMAKE_EXECUTABLE_SUFFIX .scr)
 
 add_executable(${PROJECT_NAME} WIN32 ${APP_SRC} ${APP_RESOURCES})
 target_link_libraries(${PROJECT_NAME} GUI)
+target_link_libraries(${PROJECT_NAME} ${EXIF_LIB})
 target_link_libraries(${PROJECT_NAME} ${wxWidgets_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ".")

--- a/main.cpp
+++ b/main.cpp
@@ -62,22 +62,39 @@ class rotatingJPEGHandler : public wxJPEGHandler
         switch (result.Orientation)
         {
         case 1:
+        case 2:
             // unrotated image
             break;
         case 3:
+        case 4:
             // 180 deg off
             *image = image->Rotate180();
             break;
+        case 5:
         case 6:
             // needs correction 90 deg clockwise
             *image = image->Rotate90(true);
             break;
+        case 7:
         case 8:
             // needs correction 90 deg counterclockw
             *image = image->Rotate90(false);
             break;
         default:
             // unknown rotation
+            break;
+        }
+        switch (result.Orientation)
+        {
+        case 2:
+        case 4:
+        case 5:
+        case 7:
+            // in these cases, the image was (also) mirrored
+            *image = image->Mirror();
+            break;
+        default:
+            // not mirrored (or unknown)
             break;
         }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,6 +3,7 @@
     "name": "multi-screen-saver",
     "version-string": "1.0.0",
     "dependencies": [
+        "easyexif",
         "wxwidgets"
     ],
     "builtin-baseline": "dafef74af53669ef1cc9015f55e0ce809ead62aa"


### PR DESCRIPTION
`wxWidgets` doesn’t seem to have any support for this.

This adds code to wrap the standard file handler for JPEG to add a rotation step based on exif data.

It uses https://github.com/mayanklahiri/easyexif for parsing the metadata.

This PR currently just adds the `exif.cpp` and `exif.h` as a dependency by copying the files. I’m not at all familiar with standard practices here though, so feel free to change that as desired. (This PR branch allows edits for maintainers, so you can change that before merging if you want.) It seems e.g. that alternatively, easyexif is also available via vcpkg: https://vcpkg.io/en/package/easyexif – I personally have no idea how to set up such dependencies correctly. *[I don’t even know if this `CMakeLists.txt`-edit was correct & sufficient the way I did it here now.]*

Also note that those two files [`exif.cpp`, `exif.h`] have a different license (BSD License). The information is already part of the source files, but I’m not sure about best practices here, either; so perhaps if they are kept in-tree like that, it should additionally also be noted elsewhere?